### PR TITLE
Added Slack reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Supported reporting services:
 
 * [Sentry](https://getsentry.com/) - a great crash reporting sofrware.
 * [Hipchat](https://www.hipchat.com/) - not so great communication platform.
+* [Slack](https://slack.com/) - another communication platform.
 
 ## Quick start
 
@@ -106,6 +107,28 @@ Labels:
 * `token` - Hipchat token to authorize requests.
 
 If label is unspecified, command line flag value is used.
+
+#### Slack
+
+Command line flags:
+
+* `slack.hook_url` - Webhook URL, needed to post something (required).
+* `slack.channel` - Channel to post into, e.g. #mesos (optional).
+* `slack.username` - Username to post with, e.g. "Mesos Cluster" (optional).
+* `slack.icon_emoji` - Icon Emoji to post with, e.g. ":mesos:" (optional).
+* `slack.icon_url` - Icon URL to post with, e.g. "http://my.com/pic.png" (optional).
+
+Labels:
+
+* `hook_url` - Webhook URL, needed to post something (required).
+* `channel` - Channel to post into, e.g. #mesos (optional).
+* `username` - Username to post with, e.g. "Mesos Cluster" (optional).
+* `icon_emoji` - Icon Emoji to post with, e.g. ":mesos:" (optional).
+* `icon_url` - Icon URL to post with, e.g. "http://my.com/avatar.png" (optional).
+
+If label is unspecified, command line flag value is used.
+
+For more details see [Slack API docs](https://api.slack.com/incoming-webhooks).
 
 ### Label configuration
 

--- a/cmd/complainer/main.go
+++ b/cmd/complainer/main.go
@@ -17,7 +17,7 @@ import (
 func main() {
 	name := flag.String("name", monitor.DefaultName, "complainer name to use (default is implicit)")
 	u := flag.String("uploader", "", "uploader to use (example: s3)")
-	r := flag.String("reporters", "", "reporters to use (example: sentry,hipchat)")
+	r := flag.String("reporters", "", "reporters to use (example: sentry,hipchat,slack)")
 	masters := flag.String("masters", "", "list of master urls: http://host:port,http://host:port")
 
 	uploader.RegisterFlags()

--- a/reporter/slack.go
+++ b/reporter/slack.go
@@ -1,0 +1,147 @@
+package reporter
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/cloudflare/complainer"
+)
+
+func init() {
+	var (
+		hookURL   *string
+		username  *string
+		channel   *string
+		iconEmoji *string
+		iconURL   *string
+	)
+
+	registerMaker("slack", Maker{
+		RegisterFlags: func() {
+			hookURL = flag.String("slack.hook_url", os.Getenv("SLACK_HOOK_URL"), "default slack webhook url")
+			username = flag.String("slack.username", os.Getenv("SLACK_USERNAME"), "default slack username")
+			channel = flag.String("slack.channel", os.Getenv("SLACK_CHANNEL"), "default slack channel")
+			iconEmoji = flag.String("slack.icon_emoji", os.Getenv("SLACK_ICON_EMOJI"), "default slack user icon emoji")
+			iconURL = flag.String("slack.icon_url", os.Getenv("SLACK_ICON_URL"), "default slack user icon url")
+		},
+
+		Make: func() (Reporter, error) {
+			return newSlackReporter(*hookURL, *username, *channel, *iconEmoji, *iconURL)
+		},
+	})
+}
+
+type slackReporter struct {
+	hookURL   *url.URL
+	channel   string
+	username  string
+	iconEmoji string
+	iconURL   string
+}
+
+type slackMessage struct {
+	Channel   string `json:"channel"`
+	Username  string `json:"username"`
+	Text      string `json:"text"`
+	IconEmoji string `json:"icon_emoji"`
+	IconURL   string `json:"icon_url"`
+}
+
+func newSlackReporter(hookURL, username, channel, iconEmoji, iconURL string) (*slackReporter, error) {
+	u, err := url.Parse(hookURL)
+	if err != nil {
+		return nil, err
+	}
+
+	return &slackReporter{
+		hookURL:   u,
+		username:  username,
+		channel:   channel,
+		iconEmoji: iconEmoji,
+		iconURL:   iconURL,
+	}, nil
+}
+
+func (s *slackReporter) Report(failure complainer.Failure, config ConfigProvider, stdoutURL string, stderrURL string) error {
+	m := &slackMessage{
+		Text: fmt.Sprintf(
+			"Task %s (%s) died with status %s [<%s|stdout>, <%s|stderr>]",
+			failure.Name, failure.Slave, failure.State, stdoutURL, stderrURL,
+		),
+	}
+	var err error
+	var hookURL *url.URL
+	if u := config("hook_url"); len(u) > 0 {
+		hookURL, err = url.Parse(u)
+		if err != nil {
+			return err
+		}
+
+	} else {
+		hookURL = s.hookURL
+	}
+
+	// A hook url is the only required property here.
+	// All other properties are optional.
+	// But it's a legitimate scenario when some reporters are not fully configured.
+	// You don't always want to report all failures to all reporters.
+	// If some required parameter is missing, just silently return from Report().
+	if hookURL == nil {
+		return nil
+	}
+
+	// Fill and overwrite configuration values
+	s.fillConfigValues(m, config)
+
+	jsonMessage, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+
+	body := bytes.NewReader(jsonMessage)
+	resp, err := http.Post(hookURL.String(), "application/json", body)
+	if err != nil {
+		defer func() {
+			if resp != nil {
+				_ = resp.Body.Close()
+			}
+		}()
+	}
+
+	return err
+}
+
+func (s *slackReporter) fillConfigValues(m *slackMessage, config ConfigProvider) {
+	// Check the user name overwrite
+	if username := config("username"); len(username) > 0 {
+		m.Username = username
+	} else if len(s.username) > 0 {
+		m.Username = s.username
+	}
+
+	// Check the channel overwrite
+	if channel := config("channel"); len(channel) > 0 {
+		m.Channel = channel
+	} else if len(s.channel) > 0 {
+		m.Channel = s.channel
+	}
+
+	// Check the icon emoji overwrite
+	if emoji := config("icon_emoji"); len(emoji) > 0 {
+		m.IconEmoji = emoji
+	} else if len(s.iconEmoji) > 0 {
+		m.IconEmoji = s.iconEmoji
+	}
+
+	// Check the icon url overwrite
+	if iconURL := config("icon_url"); len(iconURL) > 0 {
+		m.IconURL = iconURL
+	} else if len(s.iconURL) > 0 {
+		m.IconURL = s.iconURL
+	}
+}


### PR DESCRIPTION
As an alternative to the hipchat reporter, this PR offers a slack reporter.
The implementation was done accordingly the [Incoming Webhooks @ Slack API docs](https://api.slack.com/incoming-webhooks).

I tested the complete env with a Slack installation and the docker mesos cluster x and a dummy chronos job:
```
echo "hallo" && sleep 20 && echo "bye bye" && exit 2
```

Start the complainer + Logs of first failures:
```
$ ./complainer -masters "http://192.168.99.100:5050" \
                     -reporters "slack" \
                     -slack.channel "#mesos" \
                     -slack.hook_url "https://hooks.slack.com/services/TOKEN" \
                     -slack.username "Mesos Cluster" \
                     -slack.icon_emoji ":mesos:" \
                     -uploader "noop"
2016/06/08 18:35:57 Reporting ChronosTask:my-failing-job (ct:1465403728460:1:my-failing-job:) from 192.168.99.100
2016/06/08 18:36:23 Reporting ChronosTask:my-failing-job (ct:1465403759309:0:my-failing-job:) from 192.168.99.100
```

Here is how such a message will look like in Slack:
<img width="823" alt="screen shot 2016-06-08 at 18 49 00" src="https://cloud.githubusercontent.com/assets/320064/15902723/b483bf62-2da9-11e6-8530-a86a60c1c6aa.png">
