### PR TITLE
Added .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+# Application
+cmd/complainer/complainer


### PR DESCRIPTION
When i compile `complainer` there is a binary in `cmd/complainer/complainer`.
This marks the git repo as dirty.

This PR offers a basic .gitignore, based on the [Go template from github/gitignore](https://github.com/github/gitignore/blob/master/Go.gitignore).