### PR TITLE
Catch tasks that are not yet promoted to completed

### DIFF
--- a/mesos/cluster.go
+++ b/mesos/cluster.go
@@ -121,7 +121,9 @@ func (c *Cluster) Logs(failure complainer.Failure) (stdoutURL, stderrURL string,
 	}
 
 	for _, framework := range append(state.Frameworks, state.CompletedFrameworks...) {
-		for _, executor := range framework.CompletedExecutors {
+		// Tasks are not necessarily promoted to completed immediately,
+		// that's why we need to look at current executors too.
+		for _, executor := range append(framework.Executors, framework.CompletedExecutors...) {
 			if executor.ID == failure.ID {
 				stdoutURL = sandboxURL(failure.Slave, executor.Directory, "stdout")
 				stderrURL = sandboxURL(failure.Slave, executor.Directory, "stderr")

--- a/mesos/state.go
+++ b/mesos/state.go
@@ -53,6 +53,7 @@ type slaveState struct {
 
 type slaveFramework struct {
 	CompletedExecutors []slaveExecutor `json:"completed_executors"`
+	Executors          []slaveExecutor `json:"executors"`
 }
 
 type slaveExecutor struct {


### PR DESCRIPTION
Example (note that `TASK_FAILED` is in `executors`, not in `completed_executors`):

```json
{
      "executors": [
        {
          "completed_tasks": [
            {
              "discovery": {
                "name": "where.example",
                "ports": {
                  "ports": [
                    {
                      "number": 11423,
                      "protocol": "tcp"
                    }
                  ]
                },
                "visibility": "FRAMEWORK"
              },
              "executor_id": "",
              "framework_id": "0b7b5ac8-acbd-47a3-b8db-4e3a2573e948-0000",
              "id": "example_where.7a576eb1-3233-11e6-b14f-0242cc304691",
              "name": "where.example",
              "resources": {
                "cpus": 1,
                "disk": 0,
                "mem": 128,
                "ports": "[11423-11423]"
              },
              "slave_id": "0b7b5ac8-acbd-47a3-b8db-4e3a2573e948-S0",
              "state": "TASK_FAILED",
              "statuses": [
                {
                  "container_status": {
                    "network_infos": [
                      {
                        "ip_address": "172.16.91.128",
                        "ip_addresses": [
                          {
                            "ip_address": "172.16.91.128"
                          }
                        ]
                      }
                    ]
                  },
                  "state": "TASK_RUNNING",
                  "timestamp": 1465910735.99492
                },
                {
                  "container_status": {
                    "network_infos": [
                      {
                        "ip_address": "172.16.91.128",
                        "ip_addresses": [
                          {
                            "ip_address": "172.16.91.128"
                          }
                        ]
                      }
                    ]
                  },
                  "state": "TASK_FAILED",
                  "timestamp": 1465910741.03546
                }
              ]
            }
          ],
          "container": "d4947b9a-d81a-4882-8493-6ebc95277065",
          "directory": "/tmp/mesos/slaves/0b7b5ac8-acbd-47a3-b8db-4e3a2573e948-S0/frameworks/0b7b5ac8-acbd-47a3-b8db-4e3a2573e948-0000/executors/example_where.7a576eb1-3233-11e6-b14f-0242cc304691/runs/d4947b9a-d81a-4882-8493-6ebc95277065",
          "id": "example_where.7a576eb1-3233-11e6-b14f-0242cc304691",
          "name": "Command Executor (Task: example_where.7a576eb1-3233-11e6-b14f-0242cc304691) (Command: sh -c 'sleep 5 && e...')",
          "queued_tasks": [],
          "resources": {
            "cpus": 0.1,
            "disk": 0,
            "mem": 32
          },
          "source": "example_where.7a576eb1-3233-11e6-b14f-0242cc304691",
          "tasks": []
        }
      ],
      "failover_timeout": 604800,
      "hostname": "dev",
      "id": "0b7b5ac8-acbd-47a3-b8db-4e3a2573e948-0000",
      "name": "marathon",
      "role": "*",
      "user": "root"
    }
  ]
}
```