### PR TITLE
Fix Slack stdout and stderr urls

### DIFF
--- a/reporter/slack.go
+++ b/reporter/slack.go
@@ -71,7 +71,7 @@ func newSlackReporter(hookURL, username, channel, iconEmoji, iconURL, format str
 }
 
 func (s *slackReporter) Report(failure complainer.Failure, config ConfigProvider, stdoutURL string, stderrURL string) error {
-	text, err := fillTemplate(failure, config, "http://p.ya.ru", "http://google.com/", s.format)
+	text, err := fillTemplate(failure, config, stdoutURL, stderrURL, s.format)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In #21 some wrong URLs for the Slack reporter (stdout and stderr) were introduced: https://github.com/cloudflare/complainer/pull/21/files#diff-753a7fa5eceb34b8763913260a62b3d7R74

This is a good example that even a code review can fail. Here is a PR to fix this :)