### PR TITLE
Add support for env vars for name, uploader, reporters and master flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,16 @@ Complainer needs two command line flags to configure itself:
 * `name` - Complainer instance name (default is `default`).
 * `masters` - Mesos master URL list (ex: `http://host:port,http://host:port`).
 
+These settings can be applied by env vars as well:
+
+* `COMPLAINER_NAME` - Complainer instance name (default is `default`).
+* `COMPLAINER_MASTERS` - Mesos master URL list (ex: `http://host:port,http://host:port`).
+
 ### Log upload services
 
-Log upload service is specified by command line flag `uploader`. Only one
-uploader can be specified per complainer instance.
+Log upload service is specified by command line flag `uploader`.
+Alternatively you can specify this by env var `COMPLAINER_UPLOADER`.
+Only one uploader can be specified per complainer instance.
 
 #### no-op
 
@@ -103,8 +109,9 @@ Flags override env variables if both are supplied.
 
 ### Reporting services
 
-Reporting services are specified by command line flag `reporters`. Several
-services can be specified, separated by comma.
+Reporting services are specified by command line flag `reporters`.
+Alternatively you can specify this by env var `COMPLAINER_REPORTERS`.
+Several services can be specified, separated by comma.
 
 #### Sentry
 

--- a/cmd/complainer/main.go
+++ b/cmd/complainer/main.go
@@ -15,10 +15,10 @@ import (
 )
 
 func main() {
-	name := flag.String("name", monitor.DefaultName, "complainer name to use (default is implicit)")
-	u := flag.String("uploader", "", "uploader to use (example: s3aws,s3goamz,noop)")
-	r := flag.String("reporters", "", "reporters to use (example: sentry,hipchat,slack,file)")
-	masters := flag.String("masters", "", "list of master urls: http://host:port,http://host:port")
+	name := flag.String("name", envOrDefault("COMPLAINER_NAME", monitor.DefaultName), "complainer name to use (default is implicit)")
+	u := flag.String("uploader", envOrDefault("COMPLAINER_UPLOADER", ""), "uploader to use (example: s3aws,s3goamz,noop)")
+	r := flag.String("reporters", envOrDefault("COMPLAINER_REPORTERS", ""), "reporters to use (example: sentry,hipchat,slack,file)")
+	masters := flag.String("masters", envOrDefault("COMPLAINER_MASTERS", ""), "list of master urls: http://host:port,http://host:port")
 
 	uploader.RegisterFlags()
 	reporter.RegisterFlags()
@@ -58,6 +58,16 @@ func main() {
 
 		time.Sleep(time.Second * 5)
 	}
+}
+
+// envOrDefault will return the value of env var key if set.
+// If not value is returned
+func envOrDefault(key, value string) string {
+	if v := os.Getenv(key); len(v) > 0 {
+		return v
+	}
+
+	return value
 }
 
 func makeReporters(requested string) (map[string]reporter.Reporter, error) {


### PR DESCRIPTION
Nearly all settings can be adjusted or set by env vars.
The required flags, like name, master, reporters or uploaders are not able to set via env vars.

This PR adds this possibility.