### PR TITLE
Add filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,23 @@ These settings can be applied by env vars as well:
 * `COMPLAINER_MASTERS` - Mesos master URL list (ex: `http://host:port,http://host:port`).
 * `COMPLAINER_LISTEN` - Listen address for HTTP (ex: `127.0.0.1:8888`).
 
+
+## Filtering based on the failures framework
+
+If you're in the situation where you have multiple marathons running against
+a mesos, and want to segregate out which failures go where, the following
+options are of interest. Each option can be specified multiple times.
+
+* `framework-whitelist` - This is a regex option; if given, the failures
+  framework must match at least one whitelist. If no whitelist is specified,
+  then it's treated as if '.*' had been passed- all failures are whitelisted
+  as long as they don't match a blacklist.
+* `framework-blacklist` - This is a regex option; if given, any failure that
+  matches this are ignored.
+
+Note that the order of evaluation is such that blacklists are applied first,
+then whitelists.
+
 ### HTTP interface
 
 Complainer provides HTTP interface. You have to enable it with `-listen`

--- a/reporter/file.go
+++ b/reporter/file.go
@@ -31,7 +31,7 @@ type fileReporter struct {
 }
 
 func newFileReporter(file, format string) (*fileReporter, error) {
-	f, err := os.OpenFile(file, os.O_APPEND|os.O_CREATE, 0666)
+	f, err := os.OpenFile(file, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This adds filtering functionality for failures, based on the framework name.  This is primarily useful if you're in a situation where you have multiple marathons, and want to filter which failures go where.