### PR TITLE
Add new HTTP Route: /version

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ and `500 Internal Server Error` when complainer cannot talk to Mesos.
 We don't check for other issues (uploader and reporter failures) because they
 are not guaranteed to be happening continuously to recover themselves.
 
+#### version endpoint
+
+`/version` endpoint reports `200 OK` and outputs the current version of this application.
+
+```
+complainer (default) v1.7.0
+```
+
 #### pprof endpoint
 
 `/debug/pprof` endpoint exposes the regular `net/http/pprof` interface:

--- a/cmd/complainer/main.go
+++ b/cmd/complainer/main.go
@@ -17,6 +17,11 @@ import (
 	"github.com/cloudflare/complainer/uploader"
 )
 
+const (
+	// Version of complainer
+	Version = "1.7.0"
+)
+
 type regexArrayFlags []*regexp.Regexp
 
 func (a *regexArrayFlags) String() string {
@@ -76,7 +81,7 @@ func main() {
 	matcher := matcher.RegexMatcher{Whitelist: whitelist, Blacklist: blacklist}
 	cluster := mesos.NewCluster(strings.Split(*masters, ","))
 
-	m := monitor.NewMonitor(*name, cluster, up, reporters, *d, &matcher)
+	m := monitor.NewMonitor(*name, Version, cluster, up, reporters, *d, &matcher)
 
 	serve(m, *listen)
 


### PR DESCRIPTION
This PR adds a new HTTP Route `/version`.

This is useful to check the version of complainer that is deployed in production.

How to run:
```
$ go build && ./complainer -uploader=noop -masters="http://127.0.0.1:5050" -reporters="file" -file.name="./foo.log" -listen="0.0.0.0:44556"
```

How to test
```
$ curl -v http://127.0.0.1:44556/version
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 44556 (#0)
> GET /version HTTP/1.1
> Host: 127.0.0.1:44556
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Mon, 31 Jul 2017 11:37:09 GMT
< Content-Length: 28
< Content-Type: text/plain; charset=utf-8
<
complainer (default) v1.7.0
* Connection #0 to host 127.0.0.1 left intact
```

This is especially helpful when someone deployed the docker image latest (see #51).

One disadvantage here: Every release the version in `cmd/complainer/main.go` needs to be adjusted.